### PR TITLE
Bump validator's version to avoid regular expression denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "validator": "~1.5.1"
+    "validator": ">=3.22.1"
   },
   "devDependencies": {
     "mocha": "~1.13.0"


### PR DESCRIPTION
As mentioned in https://github.com/danmactough/node-resanitize/issues/8, we need to bump the version of validator to avoid regular expression denial of service.